### PR TITLE
Feature: Implementação básica de NPCs e diálogo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,102 +1,139 @@
 # biblio-almas
 Um protótipo de um jogo adventure.
-Documento de Design de Jogo: A Biblioteca das Almas Perdidas
-1. Título: A Biblioteca das Almas Perdidas
-2. Logline:
+## Documento de Design de Jogo: A Biblioteca das Almas Perdidas
+
+## 1. Título
+A Biblioteca das Almas Perdidas
+
+## 2. Logline
 Preso em uma biblioteca etérea e infinita onde cada livro é a essência de uma alma, o jogador deve desvendar segredos arcanos, interagir com histórias vivas e navegar por corredores que desafiam a lógica para encontrar um caminho de volta à realidade – ou aceitar um novo propósito entre as prateleiras do conhecimento eterno.
-3. Gênero:
+
+## 3. Gênero
 Aventura em Texto (Interactive Fiction) / Puzzle / Fantasia Mística
-4. Público-Alvo:
+
+## 4. Público-Alvo
 Jogadores que apreciam narrativas imersivas, resolução de quebra-cabeças baseados em lógica e exploração textual. Fãs de obras como "As Crônicas de Nárnia" (aspecto de entrar em outros mundos), contos de Jorge Luis Borges (bibliotecas infinitas, paradoxos), ou jogos como Zork e The Librarians (série de TV).
-5. Visão Geral da Jogabilidade (Gameplay Loop):
-O jogador interage com o mundo através de comandos de texto simples (ex: IR NORTE, PEGAR LIVRO, LER PERGAMINHO). O ciclo principal envolve:
-1.  Exploração: Mover-se entre diferentes seções, salas e corredores da Biblioteca.
-2.  Observação: Examinar o ambiente, objetos, inscrições e livros para coletar pistas.
-3.  Interação: Pegar itens, usar itens em outros objetos ou no ambiente, falar com entidades.
-4.  Resolução de Puzzles: Utilizar a lógica e os itens coletados para superar obstáculos, desbloquear novas áreas ou progredir na narrativa.
-5.  Mergulho em Livros: Entrar em "mundos-livro" para vivenciar histórias e resolver quebra-cabeças internos que podem afetar a Biblioteca maior.
-6. Mundo do Jogo (Setting):
- * A Biblioteca: Uma entidade semi-senciente, vasta e aparentemente infinita. Não segue as leis normais da física ou do tempo. Seus corredores podem mudar, e suas seções podem refletir gêneros literários, emoções ou eras históricas.
-   * O Átrio de Chegada: Ponto de partida, um local majestoso e um pouco intimidante.
-   * Corredores Labirínticos: Conectam diferentes seções. Alguns podem ser estáveis, outros podem mudar suas conexões.
-   * Seções Temáticas:
-     * A Ala dos Contos Inacabados: Livros com histórias que precisam de uma conclusão, talvez com almas presas em loop.
-     * O Arquivo das Sabedorias Proibidas: Livros perigosos, protegidos por enigmas ou guardiões.
-     * O Jardim das Poesias Vivas: Onde as palavras dos poemas se manifestam de forma literal.
-     * A Galeria dos Bestiários Esquecidos: Livros contendo criaturas que podem, por vezes, interagir com o jogador.
-   * Salas Ocultas: Pequenas salas secretas que podem conter itens importantes, lore ou atalhos.
-   * "Mundos-Livro": Ao interagir de forma específica com certos livros (ex: ENTRAR LIVRO VERMELHO), o jogador é transportado para um cenário contido dentro da narrativa daquele livro. Cada mundo-livro é um mini-ambiente com seus próprios desafios e regras.
-7. Personagens:
- * O Jogador ("O Leitor" / "O Achado"):
-   * Sem passado definido, acorda na Biblioteca sem saber como chegou.
-   * Motivação inicial: Descobrir onde está e como escapar.
-   * Pode evoluir para um papel de curador, libertador de almas, ou buscador de um conhecimento específico.
- * O Arquivista Chefe:
-   * Uma entidade antiga e enigmática, ligada à própria Biblioteca.
-   * Pode ser um guia, um mentor, ou um antagonista sutil, dependendo das escolhas e do progresso do jogador.
-   * Comunica-se através de mensagens crípticas, livros que aparecem subitamente, ou raros encontros diretos.
- * Almas/Livros Falantes:
-   * Alguns livros podem se comunicar diretamente, representando a alma ou a história que contêm.
-   * Podem pedir ajuda, oferecer pistas, contar suas histórias, ou tentar enganar o jogador.
-   * Ex: "O Livro da Donzela Aprisionada", "O Grimório do Mago Arrependido".
- * Guardiões da Biblioteca:
-   * Entidades que protegem certas seções ou livros. Podem ser hostis, ou podem ser superados através de lógica, oferendas corretas, ou respondendo a enigmas.
-8. Narrativa e Objetivos:
- * Premissa Central: Você está perdido na Biblioteca das Almas Perdidas.
- * Objetivo Principal (pode variar ou ser escolhido pelo jogador indiretamente):
-   * Escapar: Encontrar uma saída da Biblioteca de volta à realidade.
-   * Restaurar a Ordem: A Biblioteca pode estar em desequilíbrio (livros corrompidos, almas presas injustamente). O jogador pode assumir a tarefa de consertar isso.
-   * Buscar Conhecimento: Usar os vastos recursos da Biblioteca para encontrar um conhecimento específico que o jogador (ou o Arquivista) deseja.
-   * Tornar-se o Novo Arquivista: Se o Arquivista Chefe estiver ausente, morrendo ou precisando de um sucessor.
- * Conflitos:
-   * Puzzles e enigmas que bloqueiam o progresso.
-   * Corredores que mudam, dificultando a navegação.
-   * Almas corrompidas ou hostis.
-   * Guardiões.
-   * O mistério da própria Biblioteca e como o jogador chegou lá.
-9. Mecânicas Principais:
- * Parser de Comandos:
-   * Primariamente VERBO + SUBSTANTIVO (ex: PEGAR CHAVE, LER LIVRO).
-   * Pode incluir alguns VERBO + SUBSTANTIVO + PREPOSIÇÃO + SUBSTANTIVO (ex: COLOCAR ORBE NO PEDESTAL).
-   * Comandos comuns: IR [DIREÇÃO], EXAMINAR [ALGO/LOCAL], PEGAR [ITEM], LARGAR [ITEM], USAR [ITEM], ABRIR [ALGO], FECHAR [ALGO], FALAR COM [ALGUÉM], LER [ALGO], INVENTARIO, AJUDA, SALVAR, CARREGAR.
- * Inventário:
-   * Capacidade limitada ou ilimitada (a ser definido).
-   * Itens são cruciais para resolver puzzles.
- * Sistema de Puzzles:
-   * Baseados em Itens: Usar o item certo no lugar certo (ex: chave na fechadura, um livro específico em uma estante vazia).
-   * Lógicos: Decifrar códigos, sequências, padrões descritos em textos.
-   * Narrativos: Entender a história de um livro ou de uma alma para saber como ajudá-la ou o que ela precisa.
-   * Ambientais: Interagir com o ambiente de formas específicas (ex: PUXAR ALAVANCA).
- * Mecânica de "Mergulho nos Livros":
-   * Comando específico (ex: MERGULHAR EM [NOME DO LIVRO], ENTRAR NO [LIVRO]).
-   * O jogador é transportado para um ambiente descrito no livro, com seus próprios puzzles e interações.
-   * Sair do livro pode requerer resolver seu conflito interno ou encontrar um "portal de saída" textual.
-   * Ações dentro de um livro podem ter consequências fora dele.
- * Estado do Mundo: O jogo deve rastrear:
-   * Localização do jogador.
-   * Itens no inventário.
-   * Estado dos puzzles (resolvidos/não resolvidos).
-   * Portas/passagens (abertas/fechadas).
-   * NPCs encontrados e seu estado.
-   * Eventos importantes que ocorreram.
-10. Interface do Usuário (UI):
-* Entrada: Prompt de comando (> ).
-* Saída:
-* Descrição da localização atual (nome da sala, descrição visual/sensorial, saídas visíveis, itens/personagens presentes).
-* Feedback para cada comando do jogador (ex: "Você pega a esfera luminosa.", "Não há nada com esse nome aqui.", "Não entendi o que você quis dizer com 'XYZ'.").
-* Diálogos com NPCs.
-* Comandos de Sistema: AJUDA (lista de verbos comuns), SALVAR, CARREGAR, SAIR.
-11. Escopo Inicial (Para um protótipo/primeiro capítulo):
-* O Átrio de Chegada e 2-3 seções/corredores adjacentes.
-* Introdução ao Arquivista Chefe (talvez através de uma mensagem inicial).
-* 1-2 Almas/Livros com quem interagir.
-* 1 Livro "mergulhável" com um puzzle simples dentro dele.
-* 2-3 puzzles principais para progredir entre as primeiras áreas.
-* Objetivo inicial claro: Sair do Átrio ou encontrar o primeiro fragmento de informação sobre a natureza da Biblioteca.
-12. Possíveis Expansões Futuras:
-* Múltiplos finais baseados nas escolhas e ações.
-* Um sistema de "corrupção" ou "purificação" de livros/almas.
-* Um antagonista mais ativo tentando distorcer ou destruir a Biblioteca.
-* Habilidades especiais que o jogador pode aprender (ex: "Sentir Ecos de Histórias", "Decifrar Linguagens Antigas").
-* Maior variedade de seções e mundos-livro.
+
+## 5. Visão Geral da Jogabilidade (Gameplay Loop)
+O jogador interage com o mundo através de comandos de texto simples (ex: `IR NORTE`, `PEGAR LIVRO`, `LER PERGAMINHO`). O ciclo principal envolve:
+
+1.  **Exploração:** Mover-se entre diferentes seções, salas e corredores da Biblioteca.
+2.  **Observação:** Examinar o ambiente, objetos, inscrições e livros para coletar pistas.
+3.  **Interação:** Pegar itens, usar itens em outros objetos ou no ambiente, falar com entidades.
+4.  **Resolução de Puzzles:** Utilizar a lógica e os itens coletados para superar obstáculos, desbloquear novas áreas ou progredir na narrativa.
+5.  **Mergulho em Livros:** Entrar em "mundos-livro" para vivenciar histórias e resolver quebra-cabeças internos que podem afetar a Biblioteca maior.
+
+## 6. Mundo do Jogo (Setting)
+### A Biblioteca
+Uma entidade semi-senciente, vasta e aparentemente infinita. Não segue as leis normais da física ou do tempo. Seus corredores podem mudar, e suas seções podem refletir gêneros literários, emoções ou eras históricas.
+
+*   **O Átrio de Chegada:** Ponto de partida, um local majestoso e um pouco intimidante.
+*   **Corredores Labirínticos:** Conectam diferentes seções. Alguns podem ser estáveis, outros podem mudar suas conexões.
+*   **Seções Temáticas:**
+    *   **A Ala dos Contos Inacabados:** Livros com histórias que precisam de uma conclusão, talvez com almas presas em loop.
+    *   **O Arquivo das Sabedorias Proibidas:** Livros perigosos, protegidos por enigmas ou guardiões.
+    *   **O Jardim das Poesias Vivas:** Onde as palavras dos poemas se manifestam de forma literal.
+    *   **A Galeria dos Bestiários Esquecidos:** Livros contendo criaturas que podem, por vezes, interagir com o jogador.
+*   **Salas Ocultas:** Pequenas salas secretas que podem conter itens importantes, lore ou atalhos.
+*   **"Mundos-Livro":** Ao interagir de forma específica com certos livros (ex: `ENTRAR LIVRO VERMELHO`), o jogador é transportado para um cenário contido dentro da narrativa daquele livro. Cada mundo-livro é um mini-ambiente com seus próprios desafios e regras.
+
+## 7. Personagens
+### O Jogador ("O Leitor" / "O Achado")
+*   Sem passado definido, acorda na Biblioteca sem saber como chegou.
+*   Motivação inicial: Descobrir onde está e como escapar.
+*   Pode evoluir para um papel de curador, libertador de almas, ou buscador de um conhecimento específico.
+
+### O Arquivista Chefe
+*   Uma entidade antiga e enigmática, ligada à própria Biblioteca.
+*   Pode ser um guia, um mentor, ou um antagonista sutil, dependendo das escolhas e do progresso do jogador.
+*   Comunica-se através de mensagens crípticas, livros que aparecem subitamente, ou raros encontros diretos.
+
+### Almas/Livros Falantes
+*   Alguns livros podem se comunicar diretamente, representando a alma ou a história que contêm.
+*   Podem pedir ajuda, oferecer pistas, contar suas histórias, ou tentar enganar o jogador.
+*   Ex: "O Livro da Donzela Aprisionada", "O Grimório do Mago Arrependido".
+
+### Guardiões da Biblioteca
+*   Entidades que protegem certas seções ou livros. Podem ser hostis, ou podem ser superados através de lógica, oferendas corretas, ou respondendo a enigmas.
+
+### Estratégia de Introdução de NPCs
+
+Para enriquecer a exploração e a narrativa, a introdução de novos NPCs (Almas/Livros Falantes, Guardiões específicos, ou outros habitantes da Biblioteca) será frequentemente vinculada à descoberta de novas áreas ou seções temáticas da Biblioteca. Cada nova região explorável poderá apresentar personagens únicos que oferecem pistas, desafios, ou aprofundam a lore daquele local específico e da Biblioteca como um todo.
+
+## 8. Narrativa e Objetivos
+### Premissa Central
+Você está perdido na Biblioteca das Almas Perdidas.
+
+### Objetivo Principal
+(pode variar ou ser escolhido pelo jogador indiretamente):
+*   **Escapar:** Encontrar uma saída da Biblioteca de volta à realidade.
+*   **Restaurar a Ordem:** A Biblioteca pode estar em desequilíbrio (livros corrompidos, almas presas injustamente). O jogador pode assumir a tarefa de consertar isso.
+*   **Buscar Conhecimento:** Usar os vastos recursos da Biblioteca para encontrar um conhecimento específico que o jogador (ou o Arquivista) deseja.
+*   **Tornar-se o Novo Arquivista:** Se o Arquivista Chefe estiver ausente, morrendo ou precisando de um sucessor.
+
+### Conflitos
+*   Puzzles e enigmas que bloqueiam o progresso.
+*   Corredores que mudam, dificultando a navegação.
+*   Almas corrompidas ou hostis.
+*   Guardiões.
+*   O mistério da própria Biblioteca e como o jogador chegou lá.
+
+## 9. Mecânicas Principais
+### Parser de Comandos
+*   Primariamente `VERBO + SUBSTANTIVO` (ex: `PEGAR CHAVE`, `LER LIVRO`).
+*   Pode incluir alguns `VERBO + SUBSTANTIVO + PREPOSIÇÃO + SUBSTANTIVO` (ex: `COLOCAR ORBE NO PEDESTAL`).
+*   Comandos comuns: `IR [DIREÇÃO]`, `EXAMINAR [ALGO/LOCAL]`, `PEGAR [ITEM]`, `LARGAR [ITEM]`, `USAR [ITEM]`, `ABRIR [ALGO]`, `FECHAR [ALGO]`, `FALAR COM [ALGUÉM]`, `LER [ALGO]`, `INVENTARIO`, `AJUDA`, `SALVAR`, `CARREGAR`.
+
+### Inventário
+*   Capacidade limitada ou ilimitada (a ser definido).
+*   Itens são cruciais para resolver puzzles.
+
+### Sistema de Puzzles
+*   **Baseados em Itens:** Usar o item certo no lugar certo (ex: chave na fechadura, um livro específico em uma estante vazia).
+*   **Lógicos:** Decifrar códigos, sequências, padrões descritos em textos.
+*   **Narrativos:** Entender a história de um livro ou de uma alma para saber como ajudá-la ou o que ela precisa.
+*   **Ambientais:** Interagir com o ambiente de formas específicas (ex: `PUXAR ALAVANCA`).
+
+### Mecânica de "Mergulho nos Livros"
+*   Comando específico (ex: `MERGULHAR EM [NOME DO LIVRO]`, `ENTRAR NO [LIVRO]`).
+*   O jogador é transportado para um ambiente descrito no livro, com seus próprios puzzles e interações.
+*   Sair do livro pode requerer resolver seu conflito interno ou encontrar um "portal de saída" textual.
+*   Ações dentro de um livro podem ter consequências fora dele.
+
+### Estado do Mundo
+O jogo deve rastrear:
+*   Localização do jogador.
+*   Itens no inventário.
+*   Estado dos puzzles (resolvidos/não resolvidos).
+*   Portas/passagens (abertas/fechadas).
+*   NPCs encontrados e seu estado.
+*   Eventos importantes que ocorreram.
+
+## 10. Interface do Usuário (UI)
+### Entrada
+Prompt de comando (`> `).
+
+### Saída
+*   Descrição da localização atual (nome da sala, descrição visual/sensorial, saídas visíveis, itens/personagens presentes).
+*   Feedback para cada comando do jogador (ex: "Você pega a esfera luminosa.", "Não há nada com esse nome aqui.", "Não entendi o que você quis dizer com 'XYZ'.").
+*   Diálogos com NPCs.
+
+### Comandos de Sistema
+`AJUDA` (lista de verbos comuns), `SALVAR`, `CARREGAR`, `SAIR`.
+
+## 11. Escopo Inicial (Para um protótipo/primeiro capítulo)
+*   O Átrio de Chegada e 2-3 seções/corredores adjacentes.
+*   Introdução ao Arquivista Chefe (talvez através de uma mensagem inicial).
+*   1-2 Almas/Livros com quem interagir.
+*   1 Livro "mergulhável" com um puzzle simples dentro dele.
+*   2-3 puzzles principais para progredir entre as primeiras áreas.
+*   Objetivo inicial claro: Sair do Átrio ou encontrar o primeiro fragmento de informação sobre a natureza da Biblioteca.
+
+## 12. Possíveis Expansões Futuras
+*   Múltiplos finais baseados nas escolhas e ações.
+*   Um sistema de "corrupção" ou "purificação" de livros/almas.
+*   Um antagonista mais ativo tentando distorcer ou destruir a Biblioteca.
+*   Habilidades especiais que o jogador pode aprender (ex: "Sentir Ecos de Histórias", "Decifrar Linguagens Antigas").
+*   Maior variedade de seções e mundos-livro.
+
 Este documento serve como um guia inicial. Muitos detalhes serão descobertos e refinados durante o processo de desenvolvimento e escrita. O foco deve ser em criar uma atmosfera rica e puzzles inteligentes que recompensem a atenção e a curiosidade do jogador.

--- a/biblio-almas.asd
+++ b/biblio-almas.asd
@@ -1,0 +1,16 @@
+(asdf:defsystem #:biblio-almas
+  :description "Um protótipo de um jogo adventure - A Biblioteca das Almas Perdidas."
+  :version "0.0.1"
+  :author "Jules <ai.dev.google@example.com>" ; Placeholder author
+  :license "MIT"
+  :depends-on ()
+  :serial t
+  :components ((:file "src/package")
+               (:file "src/config" :depends-on ("src/package"))
+               (:file "src/utils" :depends-on ("src/package"))
+               (:file "src/world" :depends-on ("src/package"))
+               (:file "src/npc" :depends-on ("src/package" "src/world"))
+               (:file "src/player" :depends-on ("src/package" "src/world"))
+               (:file "src/parser" :depends-on ("src/package"))
+               (:file "src/engine" :depends-on ("src/package" "src/world" "src/player" "src/parser" "src/npc"))
+               (:file "src/main" :depends-on ("src/package" "src/engine"))))

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -1,0 +1,3 @@
+;;; src/config.lisp
+(in-package #:biblio-almas-game)
+;; Configurações e constantes do jogo irão aqui.

--- a/src/engine.lisp
+++ b/src/engine.lisp
@@ -1,0 +1,189 @@
+;;; src/engine.lisp
+(in-package #:biblio-almas-game)
+
+(defun mostrar-saidas (sala)
+  "Imprime as saídas disponíveis da sala."
+  (if (hash-table-count (sala-saidas sala))
+      (progn
+        (format t "Saídas óbvias: ")
+        (loop :for direcao :being :the :hash-keys :of (sala-saidas sala)
+              :do (format t "~a " (string-downcase (symbol-name direcao))))
+        (format t "~%"))
+      (format t "Não há saídas óbvias daqui.~%")))
+
+(defun mostrar-objetos-na-sala (sala-id)
+  "Imprime os nomes dos objetos visíveis na sala."
+  (let ((nomes-objetos (obter-nomes-objetos-na-sala sala-id)))
+    (if nomes-objetos
+        (format t "Você vê aqui: ~{~a~^, ~}.~%" nomes-objetos)
+        )))
+
+(defun mostrar-npcs-na-sala (sala-id)
+  "Imprime as descrições curtas dos NPCs na sala."
+  (let ((descricoes-npcs (obter-descricoes-curtas-npcs-na-sala sala-id)))
+    (when descricoes-npcs
+      (if (= (length descricoes-npcs) 1)
+          (format t "Perto dali, você nota ~A.~%" (first descricoes-npcs))
+          (format t "Perto dali, você nota: ~{~A~^; ~}.~%" descricoes-npcs)))))
+
+
+(defun descrever-localizacao-atual ()
+  "Descreve a localização atual do jogador."
+  (let ((sala-atual (obter-sala *localizacao-atual-jogador*)))
+    (if sala-atual
+        (progn
+          (format t "~%~a~%" (sala-nome sala-atual))
+          (format t "~a~%" (sala-descricao sala-atual))
+          (mostrar-objetos-na-sala *localizacao-atual-jogador*)
+          (mostrar-npcs-na-sala *localizacao-atual-jogador*)
+          (mostrar-saidas sala-atual))
+        (format t "Erro: O jogador está em uma localização desconhecida (~a).~%" *localizacao-atual-jogador*))))
+
+(defun tentar-mover (direcao)
+  "Tenta mover o jogador para a DIRECAO especificada."
+  (let* ((sala-atual (obter-sala *localizacao-atual-jogador*))
+         (id-sala-destino (gethash direcao (sala-saidas sala-atual))))
+    (if id-sala-destino
+        (let ((sala-destino (obter-sala id-sala-destino)))
+          (if sala-destino
+              (progn
+                (setf *localizacao-atual-jogador* id-sala-destino)
+                t)
+              (progn
+                (format t "Erro: A sala de destino '~a' não existe! Verifique a definição das salas.~%" id-sala-destino)
+                nil)))
+        (progn
+          (format t "Você não pode ir nessa direção.~%")
+          nil))))
+
+(defun tentar-examinar (alvo-id)
+  "Tenta examinar um ALVO-ID (pode ser :SALA, um objeto na sala ou no inventário, ou um NPC)."
+  (cond
+    ((or (null alvo-id) (eq alvo-id :sala))
+     (descrever-localizacao-atual)
+     t)
+    (t
+     (let* ((objeto-def (obter-objeto-definido alvo-id))
+            (npc-modelo (obter-npc-modelo alvo-id))
+            (objeto-na-sala (and objeto-def (objeto-esta-na-sala-p alvo-id *localizacao-atual-jogador*)))
+            (objeto-no-inventario (and objeto-def (jogador-tem-objeto-p alvo-id)))
+            (npc-na-sala (and npc-modelo (find alvo-id (sala-npcs (obter-sala *localizacao-atual-jogador*))))))
+       (cond
+         (objeto-na-sala
+          (format t "~a~%" (objeto-descricao objeto-def)) t)
+         (objeto-no-inventario
+          (format t "~a~%" (objeto-descricao objeto-def)) t)
+         (npc-na-sala
+          (format t "Você olha para ~a. ~a.~%" (npc-nome npc-modelo) (npc-descricao-curta npc-modelo))
+          t)
+         (t
+          (format t "Você não vê nenhum(a) ~a por aqui para examinar.~%" (string-downcase (symbol-name alvo-id)))
+          nil))))))
+
+(defun tentar-pegar (objeto-id)
+  "Tenta pegar um OBJETO-ID da sala atual."
+  (unless objeto-id (format t "Pegar o quê?~%") (return-from tentar-pegar nil))
+  (let ((objeto-def (obter-objeto-definido objeto-id)))
+    (cond
+      ((not (objeto-esta-na-sala-p objeto-id *localizacao-atual-jogador*))
+       (format t "Não há nenhum(a) ~a aqui.~%" (string-downcase (symbol-name objeto-id))) nil)
+      ((not objeto-def)
+       (format t "Isso não é um objeto que possa ser definido (~a).~%" objeto-id) nil)
+      ((not (objeto-pegavel objeto-def))
+       (format t "Você não pode pegar ~a.~%" (objeto-nome objeto-def)) nil)
+      (t
+       (remover-objeto-da-sala objeto-id *localizacao-atual-jogador*)
+       (adicionar-ao-inventario objeto-id)
+       (format t "Você pegou ~a.~%" (objeto-nome objeto-def))
+       t))))
+
+(defun tentar-largar (objeto-id)
+  "Tenta largar um OBJETO-ID do inventário na sala atual."
+  (unless objeto-id (format t "Largar o quê?~%") (return-from tentar-largar nil))
+  (let ((objeto-def (obter-objeto-definido objeto-id)))
+    (cond
+      ((not (jogador-tem-objeto-p objeto-id))
+       (format t "Você não está carregando nenhum(a) ~a.~%" (string-downcase (symbol-name objeto-id))) nil)
+      ((not objeto-def)
+        (format t "Este objeto (~a) não tem uma definição.~%" objeto-id) nil)
+      (t
+       (remover-do-inventario objeto-id)
+       (addicionar-objeto-a-sala objeto-id *localizacao-atual-jogador*)
+       (format t "Você largou ~a.~%" (objeto-nome objeto-def))
+       t)))))
+
+(defun mostrar-inventario ()
+  "Mostra os objetos no inventário do jogador."
+  (if *inventario-jogador*
+      (progn
+        (format t "Você está carregando:~%")
+        (loop :for obj-id :in *inventario-jogador*
+              :do (let ((obj-def (obter-objeto-definido obj-id)))
+                    (if obj-def
+                        (format t "- ~a~%" (objeto-nome obj-def))
+                        (format t "- um objeto desconhecido (ID: ~a)~%" obj-id))))))
+      (format t "Você não está carregando nada.~%"))
+  t)
+
+(defun tentar-falar (npc-id)
+  (if (not npc-id)
+      (progn (format t "Falar com quem?~%") nil)
+      (let* ((sala-atual-id *localizacao-atual-jogador*)
+             (npc-modelo (obter-npc-modelo npc-id)))
+        (cond
+          ((not npc-modelo)
+           (format t "Não conheço ninguém chamado '~A'.~%" (string-capitalize (symbol-name npc-id))) nil)
+          ((not (eq (npc-localizacao-atual npc-modelo) sala-atual-id))
+           (format t "~A não está aqui.~%" (npc-nome npc-modelo)) nil)
+          ((not (npc-dialogo npc-modelo))
+           (format t "~A não parece ter nada a dizer.~%" (npc-nome npc-modelo)) nil)
+          (t
+           (if (stringp (npc-dialogo npc-modelo))
+               (format t "~A~%" (npc-dialogo npc-modelo))
+               (format t "~A murmura algo incompreensível.~%" (npc-nome npc-modelo))) ; Placeholder
+           t))))))
+
+(defun process-command (parsed-command-list)
+  (if parsed-command-list
+      (let ((verbo (first parsed-command-list))
+            (params (rest parsed-command-list))
+            (argumento (first params))) ; O argumento principal (ID do objeto/NPC/direção)
+        (cond
+          ((eql verbo :mover)
+           (if argumento (tentar-mover argumento) (progn (format t "Mover para onde?~%") nil)))
+          ((eql verbo :examinar)
+           (tentar-examinar argumento))
+          ((eql verbo :pegar)
+           (tentar-pegar argumento))
+          ((eql verbo :largar)
+           (tentar-largar argumento))
+          ((eql verbo :inventario)
+           (mostrar-inventario))
+          ((eql verbo :falar)
+           (tentar-falar argumento))
+          ((eql verbo :desconhecido)
+           (format t "Não entendi o que você quis dizer com '~{~a~^ ~}'.~%" params) nil)
+          (t
+           (format t "Comando não implementado ainda: ~a~%" parsed-command-list) nil)))
+      (progn
+        (format t "Não entendi isso.~%")
+        nil)))
+
+(defun game-loop ()
+  (descrever-localizacao-atual)
+  (loop
+    (format t "~%> ")
+    (finish-output)
+    (let ((input (read-line)))
+      (if (string-equal input "sair")
+          (progn
+            (format t "Até logo!~%")
+            (return))
+          (let* ((parsed-command (parse-command input))
+                 (resultado-comando (process-command parsed-command)))
+            (when (and parsed-command (eql (first parsed-command) :mover) resultado-comando)
+              (descrever-localizacao-atual))
+            (when (and parsed-command (eql (first parsed-command) :examinar)
+                       (or (null (second parsed-command)) (eql (second parsed-command) :sala))
+                       resultado-comando)
+              ))))))

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -1,0 +1,6 @@
+;;; src/main.lisp
+(in-package #:biblio-almas-game)
+
+(defun start-game ()
+  (format t "Bem-vindo à Biblioteca das Almas Perdidas! (Protótipo em desenvolvimento)~%")
+  (game-loop))

--- a/src/npc.lisp
+++ b/src/npc.lisp
@@ -1,0 +1,52 @@
+;;; src/npc.lisp
+(in-package #:biblio-almas-game)
+
+(defstruct npc
+  (id nil :type symbol)
+  (nome "" :type string)
+  (descricao-curta "" :type string)
+  (dialogo nil) ; Pode ser uma string, uma lista de strings, ou uma função
+  (localizacao-atual nil :type (or null symbol))) ; ID da sala onde o NPC está
+
+(defvar *npcs-definidos* (make-hash-table :test 'eq)
+  "Tabela hash para armazenar os 'modelos' de todos os NPCs definíveis no jogo, indexados por ID.")
+
+(defun definir-npc-modelo (id nome descricao-curta &key dialogo)
+  "Define um modelo de NPC e o armazena em *npcs-definidos*."
+  (let ((novo-npc-modelo (make-npc :id id
+                                   :nome nome
+                                   :descricao-curta descricao-curta
+                                   :dialogo dialogo)))
+    (setf (gethash id *npcs-definidos*) novo-npc-modelo)
+    novo-npc-modelo))
+
+(defun obter-npc-modelo (id)
+  "Retorna o modelo de NPC do *npcs-definidos* pelo seu ID."
+  (gethash id *npcs-definidos*))
+
+(defun posicionar-npc (npc-id sala-id)
+  "Coloca uma instância de um NPC (referenciado por npc-id) em uma sala (sala-id).
+   Atualiza a lista de npcs da sala e a localização no struct do NPC."
+  (let ((npc-modelo (obter-npc-modelo npc-id))
+        (sala (obter-sala sala-id))) ; obter-sala é de world.lisp
+    (when (and npc-modelo sala)
+      ;; Adiciona o ID do NPC à lista de npcs da sala, evitando duplicatas
+      (pushnew npc-id (sala-npcs sala) :test #'eq)
+      ;; Atualiza a localização no struct do NPC (modelo)
+      (setf (npc-localizacao-atual npc-modelo) sala-id)
+      t)))
+
+(defun remover-npc-da-sala (npc-id sala-id)
+  "Remove um NPC de uma sala e define sua localização como nil."
+  (let ((npc-modelo (obter-npc-modelo npc-id))
+        (sala (obter-sala sala-id)))
+    (when (and npc-modelo sala)
+      (setf (sala-npcs sala) (remove npc-id (sala-npcs sala) :test #'eq))
+      (setf (npc-localizacao-atual npc-modelo) nil)
+      t)))
+
+;; Definição do NPC Arquivista Chefe
+(definir-npc-modelo :arquivista-chefe
+  "O Arquivista Chefe"
+  "uma figura alta e encapuzada, curvada sobre um livro antigo"
+  :dialogo "O Arquivista Chefe ergue os olhos lentamente do pesado tomo. Sua voz é como o virar de páginas antigas. \"Outro Achado... perdido entre as estantes. O que buscas, ou do que foges?\"")

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,0 +1,4 @@
+;;; src/package.lisp
+(defpackage #:biblio-almas-game
+  (:use #:cl)
+  (:export #:start-game))

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -1,0 +1,78 @@
+;;; src/parser.lisp
+(in-package #:biblio-almas-game)
+
+(defun split-string (string &optional (separator " "))
+  "Divide uma string por um separador (string ou caractere).
+   Retorna uma lista de substrings."
+  (let ((sep-char (if (characterp separator) separator (char separator 0))))
+    (loop :for i = 0 :then (1+ j)
+          :as j = (position sep-char string :start i :test #'char=)
+          :collect (subseq string i j)
+          :while j)))
+
+(defun palavras-para-id-alvo (lista-de-palavras)
+  "Converte uma lista de palavras (strings) para um ID de alvo (keyword).
+   Ex: (\"livro\" \"vermelho\") -> :LIVRO-VERMELHO
+   Ex: (\"arquivista\" \"chefe\") -> :ARQUIVISTA-CHEFE"
+  (when lista-de-palavras
+    (intern (string-upcase (format nil "~{~A~^-~}" lista-de-palavras)) :keyword)))
+
+(defun parse-command (command-string)
+  "Converte a string de comando para minúsculas, divide em palavras,
+   remove palavras vazias e retorna uma lista representando o comando."
+  (let* ((normalized-string (string-downcase command-string))
+         (words (split-string normalized-string " "))
+         (cleaned-words (remove-if (lambda (s) (string= s "")) words)))
+    (if cleaned-words
+        (let* ((verbo-str (first cleaned-words))
+               (argumentos-str (rest cleaned-words))
+               (verbo (intern (string-upcase verbo-str) :keyword)))
+          (cond
+            ;; Comandos de movimento
+            ((member verbo '(:ir :vá :seguir :go :norte :sul :leste :oeste :n :s :l :o :e :w))
+             (let ((direcao-arg-str (first argumentos-str))
+                   (direcao-final nil))
+               (cond
+                 (direcao-arg-str (setf direcao-final (intern (string-upcase direcao-arg-str) :keyword)))
+                 ((member verbo '(:norte :n)) (setf direcao-final :norte))
+                 ((member verbo '(:sul :s)) (setf direcao-final :sul))
+                 ((member verbo '(:leste :l :e)) (setf direcao-final :leste))
+                 ((member verbo '(:oeste :o :w)) (setf direcao-final :oeste)))
+
+               (if direcao-final
+                   (list :mover direcao-final)
+                   (if (member verbo '(:ir :vá :seguir :go)) ; "ir" sem direção
+                       (list :desconhecido cleaned-words)
+                       (list :mover verbo))))) ; Trata "norte" (sem argumento) como "ir norte"
+
+            ;; Examinar
+            ((member verbo '(:examinar :olhar :ler :x))
+             (if argumentos-str
+                 (list :examinar (palavras-para-id-alvo argumentos-str))
+                 (list :examinar :sala)))
+
+            ;; Pegar
+            ((member verbo '(:pegar :apanhar :coletar :get :take))
+             (if argumentos-str
+                 (list :pegar (palavras-para-id-alvo argumentos-str))
+                 (list :pegar nil)))
+
+            ;; Largar
+            ((member verbo '(:largar :soltar :deixar :drop))
+             (if argumentos-str
+                 (list :largar (palavras-para-id-alvo argumentos-str))
+                 (list :largar nil)))
+
+            ;; Inventário
+            ((member verbo '(:inventario :inv :i :pertences))
+             (list :inventario))
+
+            ;; Falar com NPC
+            ((member verbo '(:falar :conversar :perguntar :talk :ask))
+             (if argumentos-str
+                 (list :falar (palavras-para-id-alvo argumentos-str))
+                 (list :falar nil))) ; Falar sem especificar com quem
+
+            ;; Outros comandos
+            (t (list :desconhecido cleaned-words))))
+        nil))) ; Retorna nil se não houver palavras após a limpeza

--- a/src/player.lisp
+++ b/src/player.lisp
@@ -1,0 +1,22 @@
+;;; src/player.lisp
+(in-package #:biblio-almas-game)
+
+(defvar *localizacao-atual-jogador* :atrio-de-chegada
+  "O ID da sala onde o jogador está atualmente.")
+
+(defvar *inventario-jogador* nil
+  "Uma lista dos IDs dos objetos que o jogador carrega.")
+
+(defun adicionar-ao-inventario (objeto-id)
+  "Adiciona um OBJETO-ID ao inventário do jogador."
+  (pushnew objeto-id *inventario-jogador* :test #'eq))
+
+(defun remover-do-inventario (objeto-id)
+  "Remove um OBJETO-ID do inventário do jogador."
+  (setf *inventario-jogador* (remove objeto-id *inventario-jogador* :test #'eq)))
+
+(defun jogador-tem-objeto-p (objeto-id)
+  "Verifica se o jogador possui o OBJETO-ID no inventário."
+  (member objeto-id *inventario-jogador* :test #'eq))
+
+;; Definições do jogador e inventário irão aqui.

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -1,0 +1,3 @@
+;;; src/utils.lisp
+(in-package #:biblio-almas-game)
+;; Funções utilitárias irão aqui.

--- a/src/world.lisp
+++ b/src/world.lisp
@@ -1,0 +1,121 @@
+;;; src/world.lisp
+(in-package #:biblio-almas-game)
+
+(defstruct objeto
+  id          ; symbol (keyword)
+  nome        ; string (e.g., "um livro vermelho")
+  descricao   ; string (e.g., "Um tomo antigo com capa de couro.")
+  pegavel     ; boolean
+  )
+
+(defstruct sala
+  (id nil :type symbol)
+  (nome "" :type string)
+  (descricao "" :type string)
+  (saidas (make-hash-table) :type hash-table)
+  (objetos (make-hash-table :test 'eq) :type hash-table) ; Mapeia objeto-id para o objeto-id (ou para o objeto em si, se preferir)
+  (npcs nil :type list) ; Lista de IDs dos NPCs presentes na sala
+  )
+
+(defvar *salas* (make-hash-table)
+  "Uma hash-table que mapeia IDs de salas (keywords) para objetos SALA.")
+
+(defvar *objetos-definidos* (make-hash-table :test 'eq)
+  "Uma hash-table que mapeia IDs de objetos (keywords) para objetos OBJETO.")
+
+(defun definir-objeto (id nome descricao &key (pegavel nil))
+  "Cria e armazena uma definição de objeto."
+  (let ((novo-objeto (make-objeto :id id
+                                  :nome nome
+                                  :descricao descricao
+                                  :pegavel pegavel)))
+    (setf (gethash id *objetos-definidos*) novo-objeto)
+    novo-objeto))
+
+(defun obter-objeto-definido (id)
+  "Retorna a struct OBJETO da definição global."
+  (gethash id *objetos-definidos*))
+
+(defun definir-sala (id nome descricao &key (saidas nil))
+  "Cria e armazena uma nova sala."
+  (let ((nova-sala (make-sala :id id
+                              :nome nome
+                              :descricao descricao
+                              :saidas (make-hash-table)
+                              :objetos (make-hash-table :test 'eq) ; Inicializa o hash-table de objetos
+                              :npcs nil))) ; NPCs inicializado como nil por padrão pelo defstruct
+    (loop :for (direcao destino-id) :on saidas :by #'cddr
+          :do (setf (gethash direcao (sala-saidas nova-sala)) destino-id))
+    (setf (gethash id *salas*) nova-sala)
+    nova-sala))
+
+(defun obter-sala (id)
+  "Retorna o objeto SALA correspondente ao ID, ou NIL se não encontrado."
+  (gethash id *salas*))
+
+(defun adicionar-objeto-a-sala (objeto-id sala-id)
+  "Adiciona um OBJETO-ID à lista de objetos de uma SALA-ID."
+  (let ((sala (obter-sala sala-id))
+        (objeto (obter-objeto-definido objeto-id)))
+    (if (and sala objeto)
+        (setf (gethash objeto-id (sala-objetos sala)) objeto-id) ; Armazena o ID do objeto
+        (format t "Erro: Não foi possível adicionar ~a à sala ~a. Sala ou objeto não definido.~%" objeto-id sala-id))))
+
+(defun remover-objeto-da-sala (objeto-id sala-id)
+    "Remove um OBJETO-ID da lista de objetos de uma SALA-ID."
+    (let ((sala (obter-sala sala-id)))
+        (if sala
+            (remhash objeto-id (sala-objetos sala))
+            (format t "Erro: Sala ~a não encontrada para remover objeto.~%" sala-id))))
+
+(defun objeto-esta-na-sala-p (objeto-id sala-id)
+    (let ((sala (obter-sala sala-id)))
+        (and sala (gethash objeto-id (sala-objetos sala)))))
+
+
+(definir-sala :atrio-de-chegada
+              "Átrio de Chegada"
+              "Você está em um átrio majestoso e um pouco intimidante. Poeira antiga paira no ar, iluminada por feixes de luz que emanam de altas janelas empoeiradas. Grandes estantes vazias se alinham nas paredes, sugerindo um conhecimento perdido ou esquecido. Um único corredor segue para o norte."
+              :saidas (:norte :corredor-leste))
+
+(definir-sala :corredor-leste
+              "Corredor Leste"
+              "Um corredor longo e silencioso se estende diante de você. O ar aqui é mais frio e o silêncio é quase palpável. As paredes são revestidas de pedra lisa e fria ao toque. Ao sul, você pode ver a luz fraca do Átrio de Chegada."
+              :saidas (:sul :atrio-de-chegada))
+
+;; Definir objetos
+(definir-objeto :livro-vermelho "um livro vermelho" "Um tomo antigo com capa de couro vermelho desbotado. Parece muito velho." :pegavel t)
+(definir-objeto :chave-pequena "uma chave pequena" "Uma chave de bronze pequena e ornamentada. Parece que poderia abrir algo delicado." :pegavel t)
+(definir-objeto :estatua-gargula "uma estátua de gárgula" "Uma estátua de gárgula de pedra, com uma expressão carrancuda e asas recolhidas. Está coberta de poeira." :pegavel nil)
+
+(defun obter-descricoes-curtas-npcs-na-sala (sala-id)
+  (let* ((sala (obter-sala sala-id))
+         (npc-ids (when sala (sala-npcs sala)))
+         (descricoes-curtas nil))
+    (dolist (npc-id npc-ids)
+      (let ((npc-modelo (obter-npc-modelo npc-id))) ; obter-npc-modelo de npc.lisp
+        (when npc-modelo
+          (push (npc-descricao-curta npc-modelo) descricoes-curtas))))
+    (nreverse descricoes-curtas)))
+
+(defun popular-mundo-inicial ()
+  ;; Objetos
+  (addicionar-objeto-a-sala :livro-vermelho :atrio-de-chegada)
+  (addicionar-objeto-a-sala :estatua-gargula :atrio-de-chegada)
+  (addicionar-objeto-a-sala :chave-pequena :corredor-leste)
+
+  ;; NPCs
+  (posicionar-npc :arquivista-chefe :atrio-de-chegada))
+
+
+(defun obter-nomes-objetos-na-sala (sala-id)
+  "Retorna uma lista dos nomes dos objetos visíveis na sala."
+  (let ((sala (obter-sala sala-id)))
+    (if sala
+        (loop :for obj-id :being :the :hash-keys :of (sala-objetos sala)
+              :collect (let ((obj-def (obter-objeto-definido obj-id)))
+                         (if obj-def (objeto-nome obj-def) "um objeto desconhecido")))
+        nil)))
+
+;; Popular o mundo
+(popular-mundo-inicial)


### PR DESCRIPTION
Este commit introduz a funcionalidade básica de Personagens Não Jogáveis (NPCs) no jogo "A Biblioteca das Almas Perdidas".

Principais mudanças:
- Adicionada estrutura de dados para NPCs (`id`, `nome`, `descricao-curta`, `dialogo`, `localizacao-atual`) em `src/npc.lisp`.
- Implementadas funções para definir modelos de NPCs, obter modelos, posicionar NPCs em salas e removê-los.
- A struct `sala` em `src/world.lisp` foi atualizada para rastrear NPCs presentes.
- O arquivo de sistema `biblio-almas.asd` foi atualizado para incluir `src/npc.lisp` e gerenciar dependências.
- Implementado o NPC "Arquivista Chefe":
    - Definido com nome, descrição e um diálogo inicial.
    - Posicionado no `:atrio-de-chegada`.
    - Sua presença é agora mencionada na descrição da sala.
- Adicionado o comando "FALAR COM [NPC]":
    - O parser em `src/parser.lisp` foi atualizado para reconhecer verbos como "falar", "conversar", etc., e identificar o NPC alvo.
    - O motor do jogo em `src/engine.lisp` agora possui a lógica `tentar-falar` para verificar a presença do NPC e exibir seu diálogo.
- O `README.md` foi atualizado na seção "Personagens" para incluir uma nota sobre a estratégia de introduzir novos NPCs vinculados à expansão de áreas do jogo.

Esta funcionalidade estabelece a base para futuras interações mais complexas com personagens e para o enriquecimento narrativo do mundo do jogo.