### PR TITLE
feat: Implement AJUDA command and verify NPC setup

### DIFF
--- a/src/engine.lisp
+++ b/src/engine.lisp
@@ -143,6 +143,19 @@
                (format t "~A murmura algo incompreensível.~%" (npc-nome npc-modelo))) ; Placeholder
            t))))))
 
+(defun mostrar-ajuda ()
+  "Mostra uma mensagem de ajuda com os comandos disponíveis."
+  (format t "~&Comandos disponíveis:~%")
+  (format t "  ~a~30t~a~%" "IR [DIREÇÃO] ou [DIREÇÃO]" "Para se mover. Ex: IR NORTE, SUL")
+  (format t "  ~a~30t~a~%" "EXAMINAR [ALGO/LOCAL] ou EXAMINAR" "Para observar. Ex: EXAMINAR LIVRO VERMELHO, EXAMINAR SALA")
+  (format t "  ~a~30t~a~%" "PEGAR [OBJETO]" "Para coletar itens. Ex: PEGAR CHAVE")
+  (format t "  ~a~30t~a~%" "LARGAR [OBJETO]" "Para deixar itens. Ex: LARGAR LIVRO")
+  (format t "  ~a~30t~a~%" "INVENTARIO ou I" "Para ver seus itens.")
+  (format t "  ~a~30t~a~%" "FALAR [PERSONAGEM]" "Para conversar com personagens. Ex: FALAR ARQUIVISTA")
+  (format t "  ~a~30t~a~%" "AJUDA" "Para mostrar esta mensagem.")
+  (format t "  ~a~30t~a~%" "SAIR" "Para terminar o jogo.")
+  t)
+
 (defun process-command (parsed-command-list)
   (if parsed-command-list
       (let ((verbo (first parsed-command-list))
@@ -161,6 +174,8 @@
            (mostrar-inventario))
           ((eql verbo :falar)
            (tentar-falar argumento))
+          ((eql verbo :ajuda)
+           (mostrar-ajuda))
           ((eql verbo :desconhecido)
            (format t "Não entendi o que você quis dizer com '~{~a~^ ~}'.~%" params) nil)
           (t

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -67,6 +67,10 @@
             ((member verbo '(:inventario :inv :i :pertences))
              (list :inventario))
 
+            ;; Ajuda
+            ((member verbo '(:ajuda :help))
+             (list :ajuda))
+
             ;; Falar com NPC
             ((member verbo '(:falar :conversar :perguntar :talk :ask))
              (if argumentos-str

--- a/start_game.lisp
+++ b/start_game.lisp
@@ -1,0 +1,3 @@
+(load (merge-pathnames ".sbclrc" (user-homedir-pathname)))
+(ql:quickload :biblio-almas)
+(biblio-almas-game:start-game)


### PR DESCRIPTION
I've added an AJUDA (help) command to the game engine and parser. This command provides players with a list of available actions and their syntax, improving game usability.

Changes:
- Modified `src/parser.lisp` to recognize 'ajuda' and 'help' inputs.
- Modified `src/engine.lisp` to process the new :ajuda action and display a help message.

Additionally, I reviewed the existing setup for the 'Arquivista Chefe' NPC. The NPC definition, dialogue, and placement in the initial room appear to be correctly implemented in `src/npc.lisp` and `src/world.lisp`. The `tentar-falar` function in `src/engine.lisp` should correctly handle displaying the NPC's dialogue.

Interactive testing was not possible due to environment constraints, so verification of NPC interaction is based on code analysis.